### PR TITLE
Update PostList import to _components in category page

### DIFF
--- a/src/app/blog/category/[categoryName]/page.tsx
+++ b/src/app/blog/category/[categoryName]/page.tsx
@@ -1,5 +1,5 @@
 import { getPostsByCategory } from "@/services/posts";
-import PostList from "@/app/blog/components/PostList";
+import PostList from "@/app/blog/_components/PostList";
 import { Badge } from "@/components/ui";
 
 type PageProps = {


### PR DESCRIPTION
### Motivation
- Adjust the `PostList` import to reflect that the component was moved to the `_components` directory so the category page resolves correctly.

### Description
- Change import from `@/app/blog/components/PostList` to `@/app/blog/_components/PostList` in `src/app/blog/category/[categoryName]/page.tsx`.

### Testing
- Ran `npm run build` and the TypeScript checks via `npm run typecheck`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006fc13ee0832194c1939b2661bee5)