### PR TITLE
About/Project 페이지를 에디토리얼 스타일로 통일

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# claude code
+.claude/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,281 +1,147 @@
-import { FaEnvelope, FaGithub, FaBriefcase } from "react-icons/fa6";
-import { FaCheckCircle } from "react-icons/fa";
+import Link from "next/link";
+import { FaGithub } from "react-icons/fa6";
 
 import { siteMetadata, skillsData, experienceData } from "@/data/metadata";
-import Link from "next/link";
-import { Card, Badge } from "@/components/ui";
 
-const AboutPage = async () => {
+const skillGroups = [
+  { label: "Backend", items: skillsData.backend },
+  { label: "Frontend", items: skillsData.frontend },
+  { label: "Tools", items: skillsData.tools },
+];
+
+const AboutPage = () => {
   return (
     <div className="min-h-screen">
-    
-      <div className="px-6 py-20">
-        <div className="max-w-6xl mx-auto">
-          {/* 헤더 */}
-          <div className="mb-16 border-b border-gray-200 pb-6 dark:border-gray-700">
-            <p className="mb-2 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-orange-600 dark:text-orange-400">Profile</p>
-            <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-gray-950 dark:text-white mb-3">
-              About Me
-            </h1>
-            <p className="text-base text-gray-600 dark:text-gray-300 max-w-2xl">
-              백엔드에서 풀스택으로 성장하는 개발자의 이야기
-            </p>
+      <div className="mx-auto max-w-5xl px-2 py-14 sm:px-6 sm:py-20">
+        {/* 헤더 */}
+        <header className="border-b border-gray-200 pb-8 dark:border-gray-700 sm:pb-10">
+          <p className="mb-2 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-orange-600 dark:text-orange-400">
+            Profile
+          </p>
+          <h1 className="text-3xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-4xl">
+            About
+          </h1>
+          <p className="mt-4 max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-300 sm:text-lg">
+            Java와 Spring 기반 서비스를 만들고 운영해온 5년차 {siteMetadata.occupation}{" "}
+            {siteMetadata.author}입니다.
+          </p>
+          <div className="mt-6">
+            <Link
+              href={siteMetadata.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group inline-flex items-center gap-2 font-mono text-xs text-gray-500 transition-colors hover:text-orange-600 dark:text-gray-400 dark:hover:text-orange-400"
+            >
+              <FaGithub className="h-4 w-4" aria-hidden />
+              github.com/kianpas
+            </Link>
           </div>
+        </header>
 
-          <div className="space-y-12">
-            {/* 프로필 카드 */}
-            <Card variant="elevated">
-              <div className="flex flex-col items-center text-center space-y-6">
-                {/* 프로필 이미지 */}
-                <div className="w-20 h-20 bg-orange-500 rounded-full flex items-center justify-center text-white text-2xl font-bold">
-                  {siteMetadata.author[0]}
-                </div>
-
-                {/* 기본 정보 */}
-                <div className="space-y-2">
-                  <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-                    {siteMetadata.author}
-                  </h2>
-                  <span className="inline-flex rounded-full bg-orange-100 px-3 py-1.5 text-sm font-medium text-orange-700 dark:bg-orange-950/40 dark:text-orange-300">{siteMetadata.occupation}</span>
-                  <p className="text-gray-500 dark:text-gray-400 text-sm">
-                    @ {siteMetadata.company}
-                  </p>
-                </div>
-
-                {/* 연락처 아이콘 */}
-                <div className="flex items-center gap-4 pt-2">
-                  <Link
-                    href={`mailto:${siteMetadata.email}`}
-                    className="w-10 h-10 bg-gray-100 dark:bg-gray-800 hover:bg-orange-100 dark:hover:bg-orange-950/30 rounded-full flex items-center justify-center text-gray-600 dark:text-gray-400 hover:text-orange-600 dark:hover:text-orange-400 transition-all duration-200"
-                    title="이메일 보내기"
-                  >
-                    <FaEnvelope size={16} />
-                  </Link>
-
-                  <Link
-                    href={siteMetadata.github}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="w-10 h-10 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-full flex items-center justify-center text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-all duration-200"
-                    title="GitHub 프로필"
-                  >
-                    <FaGithub size={16} />
-                  </Link>
-                </div>
-              </div>
-            </Card>
-            {/* 소개 */}
-            <Card variant="elevated">
-              <div className="space-y-4">
-                <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
-                  안녕하세요! 👋
-                </h3>
-
-                <div className="prose prose-gray dark:prose-invert max-w-none">
-                  <p>
-                    견고하고 확장성 있는 시스템을 만드는 것을 좋아하는 백엔드
-                    개발자 {siteMetadata.author}입니다.
-                  </p>
-
-                  <p>
-                    주로 Java와 Spring Framework를 사용하여 서버 개발에
-                    집중해왔습니다. 효율적인 데이터 모델 설계와 깔끔한 비즈니스
-                    로직 구현을 통해 안정적인 서비스를 만드는 것에 관심이
-                    많습니다.
-                  </p>
-
-                  <p>
-                    최근에는 사용자와 직접 상호작용하는 프론트엔드 영역에 큰
-                    매력을 느끼고 있습니다. React와 Next.js를 통해 서버와
-                    클라이언트가 어떻게 유기적으로 소통하며 사용자 경험을
-                    극대화하는지 탐구하고 있습니다.
-                  </p>
-
-                  <p>
-                    이 블로그는 백엔드 기술 경험과 풀스택 개발자로 성장하기 위한
-                    프론트엔드 학습 과정을 기록하는 공간입니다.
-                  </p>
-                </div>
-              </div>
-            </Card>
-
-            {/* 경력 */}
-            <Card variant="elevated">
-              <div className="space-y-6">
-                <div className="flex items-center gap-2">
-                  <FaBriefcase className="text-orange-500" size={20} />
-                  <h3 className="text-xl font-bold text-gray-900 dark:text-white">
-                    경력(테스트용 임시)
-                  </h3>
-                </div>
-
-                <div className="space-y-6">
-                  {experienceData.map((exp, index) => (
-                    <div key={index} className="relative">
-                      {/* 타임라인 라인 (마지막 항목 제외) */}
-                      {index < experienceData.length - 1 && (
-                        <div className="absolute left-6 top-12 w-0.5 h-full bg-gray-200 dark:bg-gray-700"></div>
-                      )}
-
-                      <div className="flex gap-4">
-                        {/* 타임라인 점 */}
-                        <div className="flex-shrink-0 w-12 h-12 bg-orange-100 dark:bg-orange-950/30 rounded-full flex items-center justify-center mt-1">
-                          <FaBriefcase
-                            className="text-orange-600 dark:text-orange-400"
-                            size={16}
-                          />
-                        </div>
-
-                        {/* 경력 내용 */}
-                        <div className="flex-1 space-y-3">
-                          <div>
-                            <h4 className="text-lg font-semibold text-gray-900 dark:text-white">
-                              {exp.position}
-                            </h4>
-                            <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
-                              <span className="font-medium">{exp.company}</span>
-                              <span>•</span>
-                              <span className="text-sm">{exp.period}</span>
-                            </div>
-                          </div>
-
-                          <p className="text-gray-600 dark:text-gray-300">
-                            {exp.description}
-                          </p>
-
-                          {/* 주요 성과 */}
-                          <div className="space-y-2">
-                            <h5 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                              주요 성과
-                            </h5>
-                            <ul className="space-y-1">
-                              {exp.achievements.map((achievement, achIndex) => (
-                                <li
-                                  key={achIndex}
-                                  className="flex items-start gap-2 text-sm text-gray-600 dark:text-gray-400"
-                                >
-                                  <FaCheckCircle
-                                    className="text-green-500 mt-0.5 flex-shrink-0"
-                                    size={12}
-                                  />
-                                  <span>{achievement}</span>
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-
-                          {/* 사용 기술 */}
-                          <div className="flex flex-wrap gap-1">
-                            {exp.technologies.map((tech) => (
-                              <Badge key={tech} variant="default" size="sm">
-                                {tech}
-                              </Badge>
-                            ))}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </Card>
-
-            {/* 기술 스택과 GitHub을 나란히 배치 */}
-            <div className="grid md:grid-cols-2 gap-8">
-              {/* 기술 스택 */}
-              <Card variant="elevated">
-                <div className="space-y-6">
-                  <h3 className="text-xl font-bold text-gray-900 dark:text-white">
-                    기술 스택
-                  </h3>
-
-                  <div className="space-y-6">
-                    <div>
-                      <div className="flex items-center gap-2 mb-3">
-                        <span className="font-mono text-xs font-semibold uppercase tracking-widest text-orange-600 dark:text-orange-400">Backend</span>
-                        <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                          주력 기술
-                        </h4>
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        {skillsData.backend.map((tech) => (
-                          <Badge key={tech} variant="default" size="sm">
-                            {tech}
-                          </Badge>
-                        ))}
-                      </div>
-                    </div>
-
-                    <div>
-                      <div className="flex items-center gap-2 mb-3">
-                        <span className="font-mono text-xs font-semibold uppercase tracking-widest text-orange-600 dark:text-orange-400">Frontend</span>
-                        <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                          학습 중
-                        </h4>
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        {skillsData.frontend.map((tech) => (
-                          <Badge key={tech} variant="default" size="sm">
-                            {tech}
-                          </Badge>
-                        ))}
-                      </div>
-                    </div>
-
-                    <div>
-                      <div className="flex items-center gap-2 mb-3">
-                        <span className="font-mono text-xs font-semibold uppercase tracking-widest text-orange-600 dark:text-orange-400">Tools</span>
-                        <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                          도구 및 기타
-                        </h4>
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        {skillsData.tools.map((tech) => (
-                          <Badge key={tech} variant="default" size="sm">
-                            {tech}
-                          </Badge>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </Card>
-
-              {/* GitHub 섹션 */}
-              <Card variant="elevated" className="flex flex-col justify-center">
-                <div className="text-center space-y-6">
-                  <div>
-                    <FaGithub
-                      className="mx-auto text-gray-400 dark:text-gray-600 mb-4"
-                      size={48}
-                    />
-                    <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
-                      GitHub
-                    </h3>
-                    <p className="text-gray-600 dark:text-gray-400">
-                      프로젝트와 코드를 확인해보세요
-                    </p>
-                  </div>
-                    <Link
-                      href={siteMetadata.github}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 rounded-lg bg-orange-500 px-5 py-3 font-semibold text-white transition-colors hover:bg-orange-600"
-                    >
-                      <FaGithub size={16} />
-                      방문하기
-                    </Link>
-                </div>
-              </Card>
-            </div>
-
-            {/* 마무리 메시지 */}
-            <div className="text-center">
-              <p className="text-gray-600 dark:text-gray-400">
-                이곳에 기록된 경험이 다른 개발자들에게 도움이 되기를 바랍니다.
+        <div className="divide-y divide-gray-200 dark:divide-gray-700">
+          {/* 소개 */}
+          <section
+            aria-labelledby="about-intro"
+            className="grid gap-6 py-10 md:grid-cols-[11rem_1fr] md:gap-12 sm:py-14"
+          >
+            <h2
+              id="about-intro"
+              className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-orange-600 dark:text-orange-400"
+            >
+              Intro
+            </h2>
+            <div className="max-w-2xl space-y-5 text-base leading-7 text-gray-700 dark:text-gray-300">
+              <p>
+                서비스의 바탕을 다지는 일을 주로 해왔습니다. 데이터 모델 설계,
+                배치 처리, 레거시 개선처럼 겉으로 드러나지 않지만 안정적인
+                운영을 좌우하는 작업에 관심이 많습니다.
+              </p>
+              <p>
+                필요하면 화면까지 직접 만듭니다. 이 블로그도 Next.js와 React로
+                직접 설계하고 운영하면서, 서버와 클라이언트의 경계에서 생기는
+                문제들을 다루고 있습니다.
+              </p>
+              <p>
+                이 블로그는 실무에서 만난 문제와 해결 과정을 기록하는
+                공간입니다. 기록이 다른 개발자에게도 참고가 되기를 바랍니다.
               </p>
             </div>
-          </div>
+          </section>
+
+          {/* 경력 */}
+          <section
+            aria-labelledby="about-experience"
+            className="grid gap-6 py-10 md:grid-cols-[11rem_1fr] md:gap-12 sm:py-14"
+          >
+            <h2
+              id="about-experience"
+              className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-orange-600 dark:text-orange-400"
+            >
+              Experience
+            </h2>
+            <div className="divide-y divide-gray-200 dark:divide-gray-700">
+              {experienceData.map((exp) => (
+                <article key={`${exp.company}-${exp.period}`} className="py-6 first:pt-0 last:pb-0">
+                  <p className="font-mono text-xs text-gray-500 dark:text-gray-400">
+                    {exp.period}
+                  </p>
+                  <h3 className="mt-2 text-lg font-bold leading-snug text-gray-900 dark:text-white">
+                    {exp.position}
+                    <span className="font-medium text-gray-500 dark:text-gray-400">
+                      {" "}
+                      · {exp.company}
+                    </span>
+                  </h3>
+                  <p className="mt-3 max-w-2xl leading-7 text-gray-600 dark:text-gray-300">
+                    {exp.description}
+                  </p>
+                  <ul className="mt-4 max-w-2xl space-y-2 text-sm leading-6 text-gray-600 dark:text-gray-400">
+                    {exp.achievements.map((achievement) => (
+                      <li key={achievement} className="flex gap-3">
+                        <span aria-hidden className="text-gray-300 dark:text-gray-600">
+                          —
+                        </span>
+                        <span>{achievement}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 font-mono text-xs text-gray-500 dark:text-gray-400">
+                    {exp.technologies.map((tech) => (
+                      <span key={tech}>#{tech}</span>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          {/* 기술 스택 */}
+          <section
+            aria-labelledby="about-stack"
+            className="grid gap-6 py-10 md:grid-cols-[11rem_1fr] md:gap-12 sm:py-14"
+          >
+            <h2
+              id="about-stack"
+              className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-orange-600 dark:text-orange-400"
+            >
+              Stack
+            </h2>
+            <dl className="max-w-2xl space-y-4">
+              {skillGroups.map((group) => (
+                <div
+                  key={group.label}
+                  className="grid gap-1 sm:grid-cols-[7rem_1fr] sm:gap-6"
+                >
+                  <dt className="font-mono text-xs font-semibold uppercase tracking-widest leading-6 text-gray-500 dark:text-gray-400">
+                    {group.label}
+                  </dt>
+                  <dd className="leading-6 text-gray-700 dark:text-gray-300">
+                    {group.items.join(", ")}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
         </div>
       </div>
     </div>

--- a/src/app/project/_components/ProjectCard.tsx
+++ b/src/app/project/_components/ProjectCard.tsx
@@ -1,104 +1,46 @@
 import { Project } from "@/types/project";
 import Link from "next/link";
-import { FaGithub, FaCalendarAlt, FaExternalLinkAlt } from "react-icons/fa";
-import { Card, Badge } from "@/components/ui";
 
 type ProjectCardProps = {
   project: Project;
 };
 
+const formatDate = (dateStr: string) => {
+  if (!dateStr) return "";
+  const [year, month] = dateStr.split("-");
+  return `${year}.${month}`;
+};
+
 const ProjectCard = ({ project }: ProjectCardProps) => {
-  const {
-    slug,
-    title,
-    description,
-    projectUrl,
-    tags,
-    startDate,
-    endDate,
-  } = project;
+  const { slug, title, description, tags, startDate, endDate } = project;
 
-  // 날짜 포맷팅 함수
-  const formatDate = (dateStr: string) => {
-    if (!dateStr) return "";
-    const [year, month] = dateStr.split("-");
-    return `${year}.${month}`;
-  };
-
-  // 기간 표시 함수
-  const getDateRange = () => {
-    if (!startDate) return "";
-
-    const start = formatDate(startDate);
-    const end = endDate ? formatDate(endDate) : "진행 중";
-
-    return `${start} - ${end}`;
-  };
+  const dateRange = startDate
+    ? `${formatDate(startDate)} - ${endDate ? formatDate(endDate) : "진행 중"}`
+    : "";
 
   return (
-    <Card 
-      variant="elevated" 
-      className="group hover:border-orange-300/60 dark:hover:border-orange-700/60 hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 h-full"
-    >
-      <div className="space-y-4 h-full flex flex-col">
-        {/* 헤더: 제목과 링크 */}
-        <div className="flex items-start justify-between gap-3">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white group-hover:text-orange-600 dark:group-hover:text-orange-400 transition-colors duration-200 flex-1">
-            <Link href={`/project/${slug}`} className="block">
-              {title}
-            </Link>
-          </h2>
-          
-          <div className="flex items-center gap-2 flex-shrink-0">
-            {projectUrl && (
-              <Link 
-                href={projectUrl} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors"
-                title="GitHub 저장소"
-              >
-                <FaGithub className="h-5 w-5" />
-              </Link>
-            )}
-            <Link
-              href={`/project/${slug}`}
-              className="text-gray-500 hover:text-orange-600 dark:text-gray-400 dark:hover:text-orange-400 transition-colors"
-              title="프로젝트 상세보기"
-            >
-              <FaExternalLinkAlt className="h-4 w-4" />
-            </Link>
-          </div>
+    <Link href={`/project/${slug}`} className="group block py-8">
+      <article className="grid gap-4 md:grid-cols-[11rem_1fr] md:gap-12">
+        <div className="font-mono text-xs leading-6 text-gray-500 dark:text-gray-400">
+          {dateRange && <p>{dateRange}</p>}
         </div>
-
-        {/* 메타데이터 */}
-        {startDate && (
-          <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-            <FaCalendarAlt size={14} />
-            <span>{getDateRange()}</span>
-          </div>
-        )}
-
-        {/* 설명 */}
-        <p className="text-gray-600 dark:text-gray-300 leading-relaxed flex-1">
-          {description}
-        </p>
-
-        {/* 태그 */}
-        <div className="flex flex-wrap gap-2 pt-4 border-t border-gray-200/50 dark:border-gray-700/50">
-          {tags.slice(0, 5).map((tag, index) => (
-            <Badge key={index} variant="default" size="sm">
-              {tag}
-            </Badge>
-          ))}
-          {tags.length > 5 && (
-            <span className="text-xs text-gray-400 self-center">
-              +{tags.length - 5}
-            </span>
+        <div>
+          <h3 className="text-xl font-bold leading-snug tracking-tight text-gray-900 transition-colors group-hover:text-orange-600 dark:text-white dark:group-hover:text-orange-400 sm:text-2xl">
+            {title}
+          </h3>
+          <p className="mt-3 max-w-2xl leading-7 text-gray-600 dark:text-gray-300">
+            {description}
+          </p>
+          {tags.length > 0 && (
+            <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 font-mono text-xs text-gray-500 dark:text-gray-400">
+              {tags.slice(0, 6).map((tag) => (
+                <span key={tag}>#{tag}</span>
+              ))}
+            </div>
           )}
         </div>
-      </div>
-    </Card>
+      </article>
+    </Link>
   );
 };
 

--- a/src/app/project/_components/ProjectList.tsx
+++ b/src/app/project/_components/ProjectList.tsx
@@ -36,19 +36,19 @@ const ProjectList = ({ initialProjects, totalPage }: ProjectListProps) => {
   };
   return (
     <>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16">
+      <div className="divide-y divide-gray-200 border-y border-gray-200 dark:divide-gray-700 dark:border-gray-700">
         {projects.map((project) => (
           <ProjectCard key={project.slug} project={project} />
         ))}
       </div>
 
       {hasMore && (
-        <div className="flex justify-center">
+        <div className="mt-10 flex justify-center">
           <button
             type="button"
             onClick={handleLoadMore}
             disabled={loading}
-            className="rounded-lg bg-orange-500 px-5 py-3 font-semibold text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-60"
+            className="text-sm font-semibold text-gray-600 transition-colors hover:text-orange-600 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-400 dark:hover:text-orange-400"
           >
             {loading ? "로딩 중..." : "더보기"}
           </button>

--- a/src/app/project/page.tsx
+++ b/src/app/project/page.tsx
@@ -8,49 +8,43 @@ const ProjectPage = () => {
   return (
     <div className="min-h-screen">
     
-      <div className="px-6 py-20">
-        <div className="max-w-5xl mx-auto">
-          {/* 헤더 */}
-          <div className="mb-16 border-b border-gray-200 pb-6 dark:border-gray-700">
-            <p className="mb-2 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-orange-600 dark:text-orange-400">
-              Work archive
-            </p>
-            <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-gray-950 dark:text-white mb-3">
-              프로젝트
-            </h1>
-            <p className="text-base text-gray-600 dark:text-gray-300 max-w-2xl">
-              실무와 개인 프로젝트를 통해 쌓아온 경험들을 소개합니다
-            </p>
-          </div>
-
-          {/* 실무 프로젝트 섹션 */}
-          <section className="mb-20">
-            <div className="mb-8">
-                <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-                  실무 프로젝트
-                </h2>
-            </div>
-            <ProjectList
-              initialProjects={professionalProjects.projects}
-              totalPage={professionalProjects.totalPages}
-              projectType="professional"
-            />
-          </section>
-
-          {/* 개인 프로젝트 섹션 */}
-          <section>
-            <div className="mb-8">
-                <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-                  개인 프로젝트
-                </h2>
-            </div>
-            <ProjectList
-              initialProjects={personalProjects.projects}
-              totalPage={personalProjects.totalPages}
-              projectType="personal"
-            />
-          </section>
+      <div className="mx-auto max-w-5xl px-2 py-14 sm:px-6 sm:py-20">
+        {/* 헤더 */}
+        <div className="mb-14 border-b border-gray-200 pb-5 dark:border-gray-700 sm:mb-16">
+          <p className="mb-2 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-orange-600 dark:text-orange-400">
+            Work archive
+          </p>
+          <h1 className="text-3xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-4xl">
+            프로젝트
+          </h1>
+          <p className="mt-3 max-w-2xl text-base text-gray-600 dark:text-gray-300">
+            실무와 개인 프로젝트를 통해 쌓아온 경험들을 소개합니다
+          </p>
         </div>
+
+        {/* 실무 프로젝트 섹션 */}
+        <section className="mb-20">
+          <h2 className="mb-7 text-xl font-bold text-gray-950 dark:text-white">
+            실무 프로젝트
+          </h2>
+          <ProjectList
+            initialProjects={professionalProjects.projects}
+            totalPage={professionalProjects.totalPages}
+            projectType="professional"
+          />
+        </section>
+
+        {/* 개인 프로젝트 섹션 */}
+        <section>
+          <h2 className="mb-7 text-xl font-bold text-gray-950 dark:text-white">
+            개인 프로젝트
+          </h2>
+          <ProjectList
+            initialProjects={personalProjects.projects}
+            totalPage={personalProjects.totalPages}
+            projectType="personal"
+          />
+        </section>
       </div>
     </div>
   );

--- a/src/data/metadata.ts
+++ b/src/data/metadata.ts
@@ -1,8 +1,6 @@
 export const siteMetadata = {
   author: '이운산',
-  occupation: '개발자',
-  company: '어딘가 멋진 회사',
-  email: 'your-email@example.com',
+  occupation: '백엔드 개발자',
   github: 'https://github.com/kianpas',
 };
 
@@ -15,17 +13,18 @@ export const skillsData = {
 // 홈 Hero에서 강조하는 대표 기술 (skillsData에서 추린 단일 출처)
 export const featuredSkills = ['Java', 'React', 'Next.js', 'TypeScript', 'Tailwind CSS'];
 
+// TODO: 실제 경력으로 교체 (회사명·기간·성과는 자리표시용 틀)
 export const experienceData = [
   {
-    company: 'IT 솔루션 회사 B',
-    position: '개발자',
-    period: '2021.12 - 2026.12',
-    description: '웹 애플리케이션 개발 및 유지보수',
+    company: '회사명',
+    position: '백엔드 개발자',
+    period: '2021.12 - 현재',
+    description: 'Java/Spring 기반 웹 서비스 개발 및 운영',
     achievements: [
-      'JSP 기반 웹 애플리케이션 개발',
-      'MyBatis를 활용한 데이터베이스 연동',
-      '레거시 시스템 리팩토링 참여',
+      '핵심 도메인 서버 개발과 운영 담당',
+      '레거시 시스템 개선 및 리팩토링',
+      '배치·연동 시스템 설계와 구현',
     ],
-    technologies: ['Java', 'JSP', 'MyBatis', 'Oracle', 'JavaScript']
-  }
+    technologies: ['Java', 'Spring Boot', 'MyBatis', 'Oracle', 'JavaScript'],
+  },
 ];


### PR DESCRIPTION
## 개요
홈/블로그에 적용된 에디토리얼 디자인(모노 아이브로우 + 오렌지 액센트 + 헤어라인 리스트)을 About/Project 페이지까지 확장해 사이트 전체의 디자인 언어를 통일합니다. 색감·테마는 기존 그대로 유지합니다.

## 변경 내용

### About (`src/app/about/page.tsx`)
- 카드 5장(프로필/소개/경력/스택/GitHub) 구조를 Intro / Experience / Stack 3개 섹션의 문서형 레이아웃으로 재구성
- 아바타·배지 칩·아이콘 원형 버튼·GitHub CTA 카드 제거, 헤더에 한 줄 소개 + GitHub 텍스트 링크만 유지
- 이메일(mailto) 노출 제거 — 공개 배포 사이트에 개인정보를 남기지 않기 위함
- 소개문을 5년차 톤(해온 일 중심)으로 재작성
- 경력: 타임라인 점·체크 아이콘 대신 기간(모노) → 직함·회사 → 성과 리스트 → `#기술` 태그 구성
- 기술 스택: Badge 칩 대신 "Backend — Java, Spring Boot, …" 텍스트 라인
- "경력(테스트용 임시)" 노출 문구 제거

### Project (`src/app/project/**`)
- 3열 카드 그리드 → 블로그 목록과 동일한 divide-y 리스트 (기간 모노 컬럼 + 제목/설명/태그)
- 행 전체를 상세 링크로 하고, 혼동을 주던 외부 링크 아이콘·중복 GitHub 아이콘 제거
- 섹션 제목과 중복되던 행별 Professional/Personal 라벨 제거
- 컨테이너를 블로그와 같은 `max-w-5xl` + 동일 패딩으로 통일, "더보기"를 텍스트 버튼으로 변경

### 기타
- `src/data/metadata.ts`: siteMetadata에서 email/company 필드 제거, 경력 데이터는 실데이터 교체 전까지 자리표시 틀로 정리 (TODO 주석)
- `.gitignore`에 `.claude/` 추가

## 검증
- `npx eslint` / `npx tsc --noEmit` 통과
- dev 서버에서 `/about`, `/project` 렌더링 확인 (라이트/다크 공통 클래스 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)