### PR TITLE
홈에 바이라인 스트립 추가

### DIFF
--- a/src/app/(home)/_components/HomeOverview.tsx
+++ b/src/app/(home)/_components/HomeOverview.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
-import { FaArrowRight } from "react-icons/fa6";
+import { FaArrowRight, FaGithub } from "react-icons/fa6";
 import { Post } from "@/types/post";
 import { Project } from "@/types/project";
+import { siteMetadata } from "@/data/metadata";
 
 type Props = {
   posts: Post[];
@@ -30,6 +31,25 @@ const HomeOverview = ({ posts, projects }: Props) => {
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-14 sm:px-6 sm:py-20">
+      <div className="mb-10 flex flex-wrap items-baseline justify-between gap-x-6 gap-y-2 sm:mb-12">
+        <p className="text-sm leading-6 text-gray-600 dark:text-gray-400">
+          <span className="font-semibold text-gray-900 dark:text-white">
+            {siteMetadata.author}
+          </span>
+          <span aria-hidden> — </span>
+          개발하며 마주친 문제와 해결의 기록
+        </p>
+        <Link
+          href={siteMetadata.github}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 font-mono text-xs text-gray-500 transition-colors hover:text-orange-600 dark:text-gray-400 dark:hover:text-orange-400"
+        >
+          <FaGithub className="h-4 w-4" aria-hidden />
+          github.com/kianpas
+        </Link>
+      </div>
+
       <section aria-labelledby="latest-heading">
         <div className="mb-8 flex items-end justify-between border-b border-gray-200 pb-5 dark:border-gray-700">
           <div>


### PR DESCRIPTION
## 개요
홈 상단에 마스트헤드 성격의 한 줄 바이라인을 추가합니다.

> **이운산** — 개발하며 마주친 문제와 해결의 기록　　`github.com/kianpas`

## 목적
- 홈 어디에도 사이트 주인이 드러나지 않던 익명 블로그 문제 해소
- 같은 구조(최신 글 대형 + 목록)라 구분이 안 되던 홈 ↔ /blog 목록의 시각적 차별화 — 바이라인은 홈에만 존재
- 히어로 부활이 아니라 한 줄 라벨: 기존 에디토리얼 문법(모노 폰트, 오렌지 hover) 그대로, 스택 강조 없는 중립 문구

## 참고
- 이메일 등 개인정보는 포함하지 않음 (GitHub는 기존 공개 링크)
- `siteMetadata` 단일 출처 사용

## 검증
- eslint 통과, dev 서버에서 홈 렌더링 및 /blog 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)