### PR TITLE
헤더 정리: 모바일 토글 버그 수정, 메뉴 타이포·활성 표시 개선

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,8 +43,14 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[60] focus:rounded-md focus:border focus:border-gray-200 focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-gray-900 dark:focus:border-gray-700 dark:focus:bg-gray-900 dark:focus:text-gray-100"
+          >
+            본문으로 건너뛰기
+          </a>
           <Navbar />
-          <main className="mt-16">{children}</main>
+          <main id="main-content" className="mt-16">{children}</main>
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -14,14 +14,14 @@ const ThemeToggle = dynamic(() => import("./ThemeToggle"), {
   ),
 });
 
-const Navbar = () => {
-  const NAV_ITEMS = [
-    { label: "Home", href: "/" },
-    { label: "Blog", href: "/blog" },
-    { label: "Project", href: "/project" },
-    { label: "About", href: "/about" },
-  ];
+// 로고가 홈 링크를 겸하므로 메뉴에는 Home을 두지 않는다
+const NAV_ITEMS = [
+  { label: "Blog", href: "/blog" },
+  { label: "Project", href: "/project" },
+  { label: "About", href: "/about" },
+];
 
+const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
 
@@ -36,25 +36,8 @@ const Navbar = () => {
     };
   }, [isOpen]);
 
-  const getLinkClassName = (href: string, isMobile: boolean = false) => {
-    //  pathname이 해당 href로 시작하면 활성화
-    const isActive =
-      href === "/" ? pathname === href : pathname.startsWith(href);
-
-    if (isMobile) {
-      return `block py-4 text-2xl text-center font-bold ${
-        isActive
-          ? "text-gray-900 dark:text-white"
-          : "text-gray-700 dark:text-gray-300"
-      }`;
-    }
-
-    return `font-bold transition-colors pb-1 ${
-      isActive
-        ? "text-gray-900 dark:text-gray-100"
-        : "text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100"
-    }`;
-  };
+  const isActive = (href: string) =>
+    href === "/" ? pathname === href : pathname.startsWith(href);
 
   return (
     <header className="fixed top-0 z-50 h-16 w-full border-b border-gray-200 bg-white/80 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/80">
@@ -69,12 +52,17 @@ const Navbar = () => {
         <div className="flex-1"></div>
 
         {/* Desktop */}
-        <nav className="hidden md:flex space-x-8">
+        <nav className="hidden md:flex items-center gap-8">
           {NAV_ITEMS.map((item) => (
             <Link
               key={item.href}
-              href={item.href === "/blog" ? "/blog/page/1" : item.href}
-              className={getLinkClassName(item.href)}
+              href={item.href}
+              aria-current={isActive(item.href) ? "page" : undefined}
+              className={`border-b-2 pb-1 text-sm transition-colors ${
+                isActive(item.href)
+                  ? "border-orange-500 font-semibold text-gray-900 dark:text-gray-100"
+                  : "border-transparent font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+              }`}
             >
               {item.label}
             </Link>
@@ -87,14 +75,14 @@ const Navbar = () => {
         </div>
 
         {/* Mobile Menu Button */}
-        <div className="md:hidden flex items-center space-x-3">
+        <div className="md:hidden relative z-50 flex items-center space-x-3">
           <ThemeToggle />
           <button
             aria-label="메뉴 열기"
             aria-expanded={!!isOpen}
             aria-controls="mobile-menu"
             onClick={() => setIsOpen(!isOpen)}
-            className="text-gray-600 dark:text-gray-300 focus:outline-none p-2 z-50 relative"
+            className="text-gray-600 dark:text-gray-300 focus:outline-none p-2"
           >
             <span className="sr-only">메인 메뉴 열기</span>
             {isOpen ? (
@@ -116,12 +104,29 @@ const Navbar = () => {
         }`}
       >
         <nav className="flex min-h-full flex-col items-center justify-center gap-8 px-6 pb-12 pt-24 text-center">
+          <Link
+            href="/"
+            onClick={() => setIsOpen(false)}
+            aria-current={pathname === "/" ? "page" : undefined}
+            className={`block py-4 text-2xl ${
+              pathname === "/"
+                ? "font-bold text-gray-900 dark:text-white"
+                : "font-medium text-gray-600 dark:text-gray-300"
+            }`}
+          >
+            Home
+          </Link>
           {NAV_ITEMS.map((item) => (
             <Link
               key={item.href}
               href={item.href}
               onClick={() => setIsOpen(false)}
-              className={getLinkClassName(item.href, true)}
+              aria-current={isActive(item.href) ? "page" : undefined}
+              className={`block py-4 text-2xl ${
+                isActive(item.href)
+                  ? "font-bold text-gray-900 dark:text-white"
+                  : "font-medium text-gray-600 dark:text-gray-300"
+              }`}
             >
               {item.label}
             </Link>


### PR DESCRIPTION
## 개요
헤더(Navbar)의 버그 1건과 디자인·일관성·접근성 이슈를 정리합니다.

## 변경 내용

### 버그 수정
- **모바일 메뉴가 열리면 테마 토글이 클릭되지 않던 문제** — 전체화면 오버레이가 DOM상 토글보다 뒤에 있어 토글을 덮고 있었음. 토글+햄버거 래퍼에 `relative z-50`을 주어 오버레이 위로 올림

### 디자인
- 데스크톱 메뉴 타이포 경량화: 전부 `font-bold`였던 링크를 `text-sm font-medium`으로 — 본문의 에디토리얼 톤과 균형
- 활성 항목 표시 강화: 진한 텍스트(semibold) + 오렌지 밑줄(`border-b-2 border-orange-500`). 기존엔 "약간 더 진한 회색"뿐이라 구분이 어려웠음
- 데스크톱 메뉴에서 `Home` 제거 — 로고가 홈 링크를 겸하므로 중복. 모바일 전체화면 메뉴에는 유지 (모바일에선 로고가 메뉴 뒤에 가려 홈 진입 수단이 필요)

### 일관성
- Blog 링크를 데스크톱(`/blog/page/1`)과 모바일(`/blog`)이 다르게 쓰던 것을 `/blog`로 통일 — next.config rewrite가 `/blog → /blog/page/1` 처리
- `NAV_ITEMS`를 컴포넌트 밖 상수로 이동

### 접근성
- 활성 링크에 `aria-current="page"`
- 레이아웃에 skip link("본문으로 건너뛰기") + `<main id="main-content">` 추가 — 키보드 포커스 시에만 표시

## 검증
- `eslint` / `tsc --noEmit` 통과
- 렌더 HTML에서 aria-current, /blog 통일, skip link 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)