### PR TITLE
모바일 메뉴가 보이지 않던 버그 수정

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -25,14 +25,31 @@ const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
 
+  // 메뉴가 열려 있는 동안 배경 스크롤 잠금
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "auto";
-    }
+    document.body.style.overflow = isOpen ? "hidden" : "";
     return () => {
-      document.body.style.overflow = "auto";
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  // 열린 메뉴는 ESC로 닫고, 데스크톱 폭으로 커지면 자동으로 닫는다
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsOpen(false);
+    };
+    const desktopQuery = window.matchMedia("(min-width: 768px)");
+    const onBreakpointChange = () => {
+      if (desktopQuery.matches) setIsOpen(false);
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    desktopQuery.addEventListener("change", onBreakpointChange);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      desktopQuery.removeEventListener("change", onBreakpointChange);
     };
   }, [isOpen]);
 
@@ -40,64 +57,67 @@ const Navbar = () => {
     href === "/" ? pathname === href : pathname.startsWith(href);
 
   return (
-    <header className="fixed top-0 z-50 h-16 w-full border-b border-gray-200 bg-white/80 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/80">
-      <div className="mx-auto flex h-full max-w-5xl items-center justify-between px-4 sm:px-6">
-        <div className="flex items-center">
-          <Link href="/" className="text-xl font-semibold">
-            BLOG
-          </Link>
-        </div>
-
-        {/* 중간 여백 */}
-        <div className="flex-1"></div>
-
-        {/* Desktop */}
-        <nav className="hidden md:flex items-center gap-8">
-          {NAV_ITEMS.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              aria-current={isActive(item.href) ? "page" : undefined}
-              className={`border-b-2 pb-1 text-sm transition-colors ${
-                isActive(item.href)
-                  ? "border-orange-500 font-semibold text-gray-900 dark:text-gray-100"
-                  : "border-transparent font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
-              }`}
-            >
-              {item.label}
+    <>
+      <header className="fixed top-0 z-50 h-16 w-full border-b border-gray-200 bg-white/80 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/80">
+        <div className="mx-auto flex h-full max-w-5xl items-center justify-between px-4 sm:px-6">
+          <div className="flex items-center">
+            <Link href="/" className="text-xl font-semibold">
+              BLOG
             </Link>
-          ))}
-        </nav>
+          </div>
 
-        {/* 테마 토글 (네비게이션 바로 옆) */}
-        <div className="hidden md:flex ml-8">
-          <ThemeToggle />
+          {/* 중간 여백 */}
+          <div className="flex-1"></div>
+
+          {/* Desktop */}
+          <nav className="hidden md:flex items-center gap-8">
+            {NAV_ITEMS.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                aria-current={isActive(item.href) ? "page" : undefined}
+                className={`border-b-2 pb-1 text-sm transition-colors ${
+                  isActive(item.href)
+                    ? "border-orange-500 font-semibold text-gray-900 dark:text-gray-100"
+                    : "border-transparent font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+                }`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+
+          {/* 테마 토글 (네비게이션 바로 옆) */}
+          <div className="hidden md:flex ml-8">
+            <ThemeToggle />
+          </div>
+
+          {/* Mobile Menu Button */}
+          <div className="md:hidden flex items-center space-x-3">
+            <ThemeToggle />
+            <button
+              aria-label={isOpen ? "메뉴 닫기" : "메뉴 열기"}
+              aria-expanded={!!isOpen}
+              aria-controls="mobile-menu"
+              onClick={() => setIsOpen(!isOpen)}
+              className="text-gray-600 dark:text-gray-300 focus:outline-none p-2"
+            >
+              {isOpen ? (
+                <FaXmark className="h-6 w-6" aria-hidden />
+              ) : (
+                <FaBars className="h-6 w-6" aria-hidden />
+              )}
+            </button>
+          </div>
         </div>
+      </header>
 
-        {/* Mobile Menu Button */}
-        <div className="md:hidden relative z-50 flex items-center space-x-3">
-          <ThemeToggle />
-          <button
-            aria-label="메뉴 열기"
-            aria-expanded={!!isOpen}
-            aria-controls="mobile-menu"
-            onClick={() => setIsOpen(!isOpen)}
-            className="text-gray-600 dark:text-gray-300 focus:outline-none p-2"
-          >
-            <span className="sr-only">메인 메뉴 열기</span>
-            {isOpen ? (
-              <FaXmark className="h-6 w-6" aria-hidden />
-            ) : (
-              <FaBars className="h-6 w-6" aria-hidden />
-            )}
-          </button>
-        </div>
-      </div>
-
-      {/* Mobile Menu (Full-Screen Overlay) */}
+      {/* Mobile Menu (Full-Screen Overlay)
+          backdrop-filter가 걸린 header 안에 두면 fixed 기준이 header가 되어
+          메뉴가 헤더 높이로 잘리므로 반드시 header 밖에 렌더링한다 */}
       <div
         id="mobile-menu"
-        className={`md:hidden fixed inset-0 bg-white dark:bg-gray-900 overflow-y-auto transition-all duration-300 ease-in-out ${
+        className={`md:hidden fixed inset-0 z-40 bg-white dark:bg-gray-900 overflow-y-auto transition-all duration-300 ease-in-out ${
           isOpen
             ? "opacity-100 translate-y-0"
             : "opacity-0 -translate-y-4 pointer-events-none"
@@ -133,7 +153,7 @@ const Navbar = () => {
           ))}
         </nav>
       </div>
-    </header>
+    </>
   );
 };
 


### PR DESCRIPTION
## 문제
모바일에서 햄버거 버튼을 눌러도 메뉴가 보이지 않음.

## 원인
CSS 스펙상 `backdrop-filter`가 적용된 요소는 `fixed` 포지션 자손의 containing block이 됩니다. PR #5에서 헤더에 `backdrop-blur-md`를 추가하면서, 헤더 **안**에 있던 `fixed inset-0` 전체화면 오버레이의 기준이 뷰포트 → 64px짜리 헤더로 바뀌어 메뉴가 헤더 높이로 잘려 사실상 보이지 않게 됐습니다. (PR #7의 z-index 수정은 이 진짜 원인을 못 잡은 것)

## 수정
- 오버레이를 `<header>` 밖의 형제 요소로 이동 — fixed 기준이 다시 뷰포트가 됨
- 오버레이 `z-40` / 헤더 `z-50`: 메뉴가 열려도 헤더(로고·토글·닫기 버튼)가 위에 유지

## 함께 개선 (검토 중 발견)
- **데스크톱 폭 전환 시 스크롤 잠금 해제** — 메뉴를 연 채 창을 768px 이상으로 키우면(태블릿 회전 등) 메뉴는 md:hidden으로 사라지는데 body 스크롤 잠금은 남아 페이지가 멈추던 문제. matchMedia 리스너로 자동 닫힘 처리
- **ESC 키로 메뉴 닫기**
- 햄버거 `aria-label`을 상태에 따라 "메뉴 열기/닫기"로 동적 변경, aria-label과 중복이던 sr-only 텍스트 제거
- 스크롤 잠금 해제 시 `overflow: auto` 강제 대신 원래 값 복원

## 검증 (dev 서버, 375×812 모바일 뷰포트)
- 햄버거 클릭 → 오버레이가 전체 뷰포트(812px) 크기, opacity 1, 링크 4개 모두 가시 영역 내
- ESC → 닫힘 + `aria-expanded=false` + 스크롤 잠금 해제
- 메뉴 연 채 800px로 리사이즈 → 자동 닫힘 + 스크롤 잠금 해제
- eslint / tsc 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)